### PR TITLE
ETCD Client Put Functionality

### DIFF
--- a/Sources/ETCD/ETCDClient.swift
+++ b/Sources/ETCD/ETCDClient.swift
@@ -102,4 +102,23 @@ public final class EtcdClient: @unchecked Sendable {
     public func delete(_ key: String) async throws {
         return try await delete(key.utf8)
     }
+    
+    /// Puts a value for a specified key in the ETCD server. If the key does not exist, a new key, value pair is created.
+    ///
+    /// - Parameters:
+    ///   - key: The key for which the value is to be put. Parameter is of type Sequence<UInt8>.
+    ///   - value: The ETCD value to put for the key. Parameter is of type Sequence<UInt8>.
+    public func put(_ key: some Sequence<UInt8>, value: some Sequence<UInt8>) async throws {
+        try await set(key, value: value)
+    }
+    
+    /// Puts a value for a specified key in the ETCD server.  If the key does not exist, a new key, value pair is created.
+    ///
+    /// - Parameters:
+    ///   - key: The key for which the value is to be put. Parameter is of type String.
+    ///   - value: The ETCD value to put for the key. Parameter is of type String.
+    public func put(_ key: String, value: String) async throws {
+        try await put(key.utf8, value: value.utf8)
+    }
+
 }

--- a/Tests/ETCDTests/ETCDTests.swift
+++ b/Tests/ETCDTests/ETCDTests.swift
@@ -70,13 +70,13 @@ final class EtcdClientTests: XCTestCase {
         
         let fetchedValue = try await etcdClient.get(key)
         XCTAssertNotNil(fetchedValue)
-        XCTAssertEqual(String(data: fetchedValue!, encoding: .utf8), "testValue")
+        XCTAssertEqual(String(data: fetchedValue!, encoding: .utf8), value)
         
         let updatedValue = "updatedValue"
         try await etcdClient.put(key, value: updatedValue)
         
         let fetchedUpdatedValue = try await etcdClient.get(key)
         XCTAssertNotNil(fetchedUpdatedValue)
-        XCTAssertEqual(String(data: fetchedUpdatedValue!, encoding: .utf8), "updatedValue")
+        XCTAssertEqual(String(data: fetchedUpdatedValue!, encoding: .utf8), updatedValue)
     }
 }

--- a/Tests/ETCDTests/ETCDTests.swift
+++ b/Tests/ETCDTests/ETCDTests.swift
@@ -62,4 +62,21 @@ final class EtcdClientTests: XCTestCase {
         fetchedValue = try await etcdClient.get(key)
         XCTAssertNil(fetchedValue)
     }
+    
+    func testUpdateExistingKey() async throws {
+        let key = "testKey"
+        let value = "testValue"
+        try await etcdClient.set(key, value: value)
+        
+        let fetchedValue = try await etcdClient.get(key)
+        XCTAssertNotNil(fetchedValue)
+        XCTAssertEqual(String(data: fetchedValue!, encoding: .utf8), "testValue")
+        
+        let updatedValue = "updatedValue"
+        try await etcdClient.put(key, value: updatedValue)
+        
+        let fetchedUpdatedValue = try await etcdClient.get(key)
+        XCTAssertNotNil(fetchedUpdatedValue)
+        XCTAssertEqual(String(data: fetchedUpdatedValue!, encoding: .utf8), "updatedValue")
+    }
 }


### PR DESCRIPTION
This PR adds put functionality to the ETCD Client. It follows the same pattern as get / set (Sequence) with a String override. For the put function, the ETCDClient does not throw an error if the key doesn't exist, it instead creates a new key, value pair with the value passed into the put function.

Repro steps:
docker compose up
swift build
swift run ETCDExample
swift test

All tests pass!