### PR TITLE
Delete Range Request

### DIFF
--- a/Sources/ETCD/DeleteRangeRequest.swift
+++ b/Sources/ETCD/DeleteRangeRequest.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-etcd-client-gsoc open source project
+//
+// Copyright (c) 2024 Apple Inc. and the swift-etcd-client-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-etcd-client-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Struct representing a delete range request in etcd server.
+public struct DeleteRangeRequest {
+    public var key: Data
+    public var rangeEnd: Data?
+    public var prevKV: Bool = false
+    
+    init(protoDeleteRangeRequest: Etcdserverpb_DeleteRangeRequest) {
+        self.key = protoDeleteRangeRequest.key
+        self.rangeEnd = protoDeleteRangeRequest.rangeEnd.isEmpty ? nil : protoDeleteRangeRequest.rangeEnd
+        self.prevKV = protoDeleteRangeRequest.prevKv
+    }
+    
+    /// Struct representing a deleteRangeRequest in etcd.
+    ///
+    /// - Parameters:
+    ///   - key: key of type Data.
+    ///   - rangeEnd: The key range to fetch until.
+    ///   - prevKV: when set, return the contents of the deleted key-value pairs.
+    public init(key: Data, rangeEnd: Data? = nil, prevKV: Bool = false) {
+        self.key = key
+        self.rangeEnd = rangeEnd
+        self.prevKV = prevKV
+    }
+    
+    func toProto() -> Etcdserverpb_DeleteRangeRequest {
+        var protoDeleteRangeRequest = Etcdserverpb_DeleteRangeRequest()
+        protoDeleteRangeRequest.key = self.key
+        if let rangeEnd = self.rangeEnd {
+            protoDeleteRangeRequest.rangeEnd = rangeEnd
+        }
+        protoDeleteRangeRequest.prevKv = self.prevKV
+        return protoDeleteRangeRequest
+    }
+}

--- a/Sources/ETCD/ETCDClient.swift
+++ b/Sources/ETCD/ETCDClient.swift
@@ -78,21 +78,13 @@ public final class EtcdClient: @unchecked Sendable {
         return kv.value
     }
     
-    /// Delete the value for a key from the ETCD server.
+    /// Delete the value for a range from the ETCD server.
     ///
-    /// - Parameter key: The key to delete. Parameter is of type Sequence<UInt8>.
-    public func delete(_ key: some Sequence<UInt8>) async throws {
-        var deleteRangeRequest = Etcdserverpb_DeleteRangeRequest()
-        deleteRangeRequest.key = Data(key)
-        let call = client.deleteRange(deleteRangeRequest)
+    /// - Parameter deleteRangeRequest: The rangeRequest to delete.
+    public func deleteRange(_ deleteRangeRequest: DeleteRangeRequest) async throws {
+        let protoDeleteRangeRequest = deleteRangeRequest.toProto()
+        let call = client.deleteRange(protoDeleteRangeRequest)
         _ = try await call.response.get()
-    }
-    
-    /// Deletes the value for a key from the ETCD server.
-    ///
-    /// - Parameter key: The key to delete the value for. Parameter is of type String.
-    public func delete(_ key: String) async throws {
-        return try await delete(key.utf8)
     }
     
     /// Puts a value for a specified key in the ETCD server. If the key does not exist, a new key, value pair is created.

--- a/Sources/ETCDExample/ETCDExample.swift
+++ b/Sources/ETCDExample/ETCDExample.swift
@@ -40,14 +40,15 @@ struct Example {
                 try await etcdClient.set("foo", value: "bar")
                 let key = "foo".data(using: .utf8)!
                 let rangeRequest = RangeRequest(key: key)
-                if let value = try await etcdClient.get(rangeRequest: rangeRequest) {
+                if let value = try await etcdClient.getRange(rangeRequest) {
                     if let stringValue = String(data: value, encoding: .utf8) {
                         print("Value is: \(stringValue)")
-                        try await etcdClient.delete("foo")
+                        let deleteRangeRequest = DeleteRangeRequest(key: key)
+                        try await etcdClient.deleteRange(deleteRangeRequest)
                         print("Key deleted")
                         
                         // Trying to get the value again
-                        let deletedValue = try await etcdClient.get(rangeRequest: rangeRequest)
+                        let deletedValue = try await etcdClient.getRange(rangeRequest)
                         if deletedValue == nil {
                             print("Key not found after deletion")
                         } else {

--- a/Tests/ETCDTests/ETCDTests.swift
+++ b/Tests/ETCDTests/ETCDTests.swift
@@ -51,7 +51,8 @@ final class EtcdClientTests: XCTestCase {
         var fetchedValue = try await etcdClient.getRange(rangeRequest)
         XCTAssertNotNil(fetchedValue)
         
-        try await etcdClient.delete(key)
+        let deleteRangeRequest = DeleteRangeRequest(key: rangeRequestKey)
+        try await etcdClient.deleteRange(deleteRangeRequest)
         
         fetchedValue = try await etcdClient.getRange(rangeRequest)
         XCTAssertNil(fetchedValue)
@@ -64,7 +65,8 @@ final class EtcdClientTests: XCTestCase {
         var fetchedValue = try await etcdClient.getRange(rangeRequest)
         XCTAssertNil(fetchedValue)
         
-        try await etcdClient.delete(key)
+        let deleteRangeRequest = DeleteRangeRequest(key: key)
+        try await etcdClient.deleteRange(deleteRangeRequest)
         
         fetchedValue = try await etcdClient.getRange(rangeRequest)
         XCTAssertNil(fetchedValue)


### PR DESCRIPTION
This PR adds support for delete ranges within etcd. The API of delete has now been changed to accept a struct of DeleteRangeRequest, which contains a key, rangeEnd, and prevKV.
https://etcd.io/docs/v3.5/learning/api/#delete-range

Updated the tests and the example.