### PR TITLE
[DO NOT MERGE] Enable strict concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DerivedData/
 Package.resolved
 .swiftpm
 /out
+.vscode

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-etcd-client-gsoc open source project
@@ -59,3 +59,9 @@ let package = Package(
         ),
     ]
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}

--- a/Tests/ETCDTests/ETCDTests.swift
+++ b/Tests/ETCDTests/ETCDTests.swift
@@ -97,12 +97,12 @@ final class EtcdClientTests: XCTestCase {
     func testWatch() async throws {
         let key = "testKey"
         let value = "testValue".data(using: .utf8)!
-
-        try await etcdClient.put(key, value: "foo")
+        let client = try XCTUnwrap(etcdClient)
+        try await client.put(key, value: "foo")
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                try await self.etcdClient.watch(key) { watchAsyncSequence in
+                try await client.watch(key) { watchAsyncSequence in
                     var iterator = watchAsyncSequence.makeAsyncIterator()
                     let events = try await iterator.next()
                     guard let events = events else {
@@ -122,7 +122,7 @@ final class EtcdClientTests: XCTestCase {
             }
 
             try await Task.sleep(nanoseconds: 1_000_000_000)
-            try await self.etcdClient.put(key, value: String(data: value, encoding: .utf8)!)
+            try await client.put(key, value: String(data: value, encoding: .utf8)!)
             group.cancelAll()
         }
     }


### PR DESCRIPTION
### Motivation:

Catch potential data races at build time.

### Modifications:

- Enabled strict concurrency checking in the Package.swift.
- Fixed up one test that emitted a concurrency warning.

### Result:

Fewer potential data races can sneak in.

### Test Plan

Library and tests build without concurrency warnings, but I wasn't able to run tests, they hung (both before and after my change), so that might need to be resolved separately first.
