### PR TITLE
[CI] Add automated release workflow using swift-temporal-sdk

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,12 @@
+name: Auto Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  auto-release:
+    uses: apple/swift-temporal-sdk/.github/workflows/auto-release.yml@main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,7 @@ We require that your commit messages match our template. The easiest way to do t
 ## How to contribute your work
 
 Please open a pull request at https://github.com/swift-server/swift-etcd-client-gsoc. Make sure the CI passes, and then wait for code review.
+
+## Automated release process
+
+This repository uses automated releases based on semantic versioning labels. See the [Auto Release Workflow documentation](https://github.com/apple/swift-temporal-sdk/blob/main/.github/workflows/README.md) for details.


### PR DESCRIPTION
Integrate swift-temporal-sdk's reusable auto-release workflow for automated semantic versioning releases. Update CONTRIBUTING.md with a link to the workflow documentation.

### Motivation

- Automate the release process using semantic versioning labels, reducing manual overhead and ensuring consistent versioning across releases.

### Modifications

- Add .github/workflows/auto-release.yml that uses swift-temporal-sdk's reusable workflow
- Update CONTRIBUTING.md with automated release process documentation linking to swift-temporal-sdk's workflow README

### Result

- When PRs are merged with semver labels (semver/patch, semver/minor), the workflow automatically creates GitHub releases. Major releases require manual creation.

### Test Plan

- Workflow will be validated after merge by labeling PRs with semver labels and verifying that releases are created automatically.